### PR TITLE
Modifications to get Goldberg to play nice with DuoStack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 source "http://rubygems.org"
 
 gem 'rake'
+gem 'rspec', '~> 2.2.0'
+gem 'rack-test', '~> 0.5.6', :require => 'rack/test'
 
 group :web do
   gem 'sinatra', '~> 1.1.2'
@@ -10,9 +12,3 @@ end
 group :development do
   gem 'ruby-debug19', '~> 0.11.6'
 end
-
-group :test do
-  gem 'rspec', '~> 2.2.0'
-  gem 'rack-test', '~> 0.5.6', :require => 'rack/test'
-end
-

--- a/README.rdoc
+++ b/README.rdoc
@@ -1,3 +1,3 @@
 Goldberg 0.0.1
 
-A CI server. With pipelines!
+A CI server. With pipelines! Now running on DuoStack!

--- a/Rakefile
+++ b/Rakefile
@@ -20,7 +20,7 @@ end
 
 desc "Start a console"
 task :console do
-  system "irb -Ilib -r lib/goldberg"
+  system "irb -Ilib -r goldberg"
 end
 
 desc "Start server at port 3000 in development mode"

--- a/Rakefile
+++ b/Rakefile
@@ -27,3 +27,13 @@ desc "Start server at port 3000 in development mode"
 task :server do
   system "rackup -E development -p 3000 config.ru"
 end
+
+directory('mnt/projects')
+
+require File.expand_path('../lib/goldberg', __FILE__)
+desc "Add a repo for Goldberg to monitor"
+task :add, [:url, :name] => [ 'mnt/projects' ] do |t, arg|
+  puts "Usage 'rake add[<url>,<name>]'" and exit if arg.count < 2
+  Goldberg::Project.add(arg)
+  puts "#{arg[:name]} successfully added."
+end

--- a/lib/goldberg/environment.rb
+++ b/lib/goldberg/environment.rb
@@ -9,7 +9,16 @@ module Goldberg
         `#{command}`
       end
 
-      [:system, :puts, :sleep].each do |method_name|
+      def system(command)
+        if block_given?
+          yield system_call_output(command), $?.success?
+          $?.success?
+        else
+          super(command)
+        end
+      end
+
+      [:puts, :sleep].each do |method_name|
         define_method method_name do |args|
           super(args)
         end

--- a/lib/goldberg/init.rb
+++ b/lib/goldberg/init.rb
@@ -42,9 +42,7 @@ module Goldberg
       while true
         Project.all.each do |p|
           p.update do |project|
-            exit_value = p.build
-            build_status = exit_value ? "passed" : "failed"
-            Environment.puts "Build #{build_status}!"
+            Environment.puts "Build #{ project.build ? "passed" : "failed!" }"
           end
         end
         Environment.puts "Sleeping for 20 seconds."

--- a/lib/goldberg/project.rb
+++ b/lib/goldberg/project.rb
@@ -21,7 +21,7 @@ module Goldberg
 
     def checkout(url)
       FileUtils.mkdir_p(File.join(Paths.projects, name))
-      if !Environment.system("git clone #{url} #{File.join(Paths.projects, name, 'code')}")
+      if !Environment.system("git clone #{url} #{code_path}")
         remove
       end
     rescue
@@ -54,7 +54,8 @@ module Goldberg
 
     def build(task = :default)
       @logger.info "Building #{name}"
-      Environment.system("cd #{code_path} ; rake #{task.to_s} > #{build_log_path}").tap do |result|
+      Environment.system("cd #{code_path} ; rake #{task.to_s} 2>&1") do |output, result|
+        Environment.write_file(build_log_path, output)
         @logger.info "Build status #{result}"
         Environment.write_file(build_status_path, result)
         File.delete(force_build_path) if File.exist?(force_build_path)

--- a/spec/goldberg/project_spec.rb
+++ b/spec/goldberg/project_spec.rb
@@ -40,7 +40,8 @@ module Goldberg
     end
 
     it "builds the default target" do
-      Environment.should_receive(:system).with('cd some_path/name/code ; rake default > some_path/name/build_log').and_return(true)
+      Environment.should_receive(:system).with('cd some_path/name/code ; rake default 2>&1').and_yield('some log data', true)
+      Environment.stub!(:write_file).with('some_path/name/build_log', 'some log data')
       Environment.stub!(:write_file).with('some_path/name/build_status', true)
       Project.new('name').build
     end


### PR DESCRIPTION
Mods I had to put in to get it working at http://goldberg.duostack.net

The biggest change was to **Goldberg::Project#build** to split the shell redirection of _rake default_\* to **build_log** into separate invocations of **Goldberg::Environment#system** and **Goldberg::Environment#write_file**. More details in relevant commit message.

As for the Gemfile, I had to move the **rspec** and **rack-test** gems up into the default bundle 'cause Duostack only install gems when deploying and (apparently) ignores **Bundler.require** calls.
