### PR TITLE
Fixed a typo, which was causing goldberg to fail on new projects

### DIFF
--- a/lib/goldberg/build.rb
+++ b/lib/goldberg/build.rb
@@ -11,7 +11,7 @@ module Goldberg
     end
 
     def self.null
-      OpenStruct.new(:number => '', :status => 'never run', :version => 'HEAD')
+      OpenStruct.new(:number => '', :status => 'never run', :version => 'HEAD', :null? => true)
     end
 
     def initialize(path)

--- a/lib/goldberg/build.rb
+++ b/lib/goldberg/build.rb
@@ -11,7 +11,7 @@ module Goldberg
     end
 
     def self.null
-      OpenStruct.new(:number => '', :status => 'never run')
+      OpenStruct.new(:number => '', :status => 'never run', :version => 'HEAD')
     end
 
     def initialize(path)

--- a/lib/goldberg/project.rb
+++ b/lib/goldberg/project.rb
@@ -62,7 +62,7 @@ module Goldberg
       latest_build_path = File.join(path('builds'), latest_build_number.to_s)
 
       if !File.exist?(latest_build_path)
-        Build.null
+        return Build.null
       end
       Build.new(latest_build_path)
     end

--- a/spec/goldberg/build_spec.rb
+++ b/spec/goldberg/build_spec.rb
@@ -16,5 +16,10 @@ module Goldberg
       Environment.should_receive(:read_file).with('/projects/name/builds/latest/build_version')
       build.version
     end
+
+    it "should be able to fake the last version" do
+      Build.null.version.should == 'HEAD'
+      Build.null.should be_null
+    end
   end
 end

--- a/spec/goldberg/project_spec.rb
+++ b/spec/goldberg/project_spec.rb
@@ -111,5 +111,21 @@ module Goldberg
       Environment.should_receive(:read_file).with('some_path/name/build_version').and_return('version')
       project.build_version
     end
+
+    it "should be able to return the latest build" do
+      project = Project.new('name')
+      project.should_receive(:latest_build_number).and_return(42)
+      File.should_receive(:exist?).with('some_path/name/builds/42').and_return(true)
+      project.latest_build.number.should == "42"
+    end
+
+    it "should be able to return a null build if the project has never been built" do
+      project = Project.new('name')
+      project.should_receive(:latest_build_number).and_return(0)
+      File.should_receive(:exist?).with('some_path/name/builds/0').and_return(false)
+      latest_build = project.latest_build
+      latest_build.number.should == ""
+      latest_build.should be_null
+    end
   end
 end


### PR DESCRIPTION
remember to use the return keyword when code is NOT in the last line in the method
