### PR TITLE
Timestamp

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,11 +4,7 @@ module ApplicationHelper
   end                  
   
   def format_timestamp(timestamp)
-#    haml_tag(:div, :class => 'timestamp') do
-       haml_concat timestamp.strftime("%a, %Y/%m/%d %I:%M%p %Z") 
-       haml_concat "( "
-       haml_concat time_ago_in_words(timestamp)       
-       haml_concat " ago )"         
-#     end
+    haml_concat timestamp.strftime("%a, %Y/%m/%d %I:%M%p %Z") 
+    haml_concat "( #{time_ago_in_words(timestamp)} ago )"
   end  
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,14 @@
 module ApplicationHelper
   def project_status(status)
     status.gsub(/ /, '_')
-  end
+  end                  
+  
+  def format_timestamp(timestamp)
+#    haml_tag(:div, :class => 'timestamp') do
+       haml_concat timestamp.strftime("%a, %Y/%m/%d %I:%M%p %Z") 
+       haml_concat "( "
+       haml_concat time_ago_in_words(timestamp)       
+       haml_concat " ago )"         
+#     end
+  end  
 end

--- a/app/views/builds/show.html.haml
+++ b/app/views/builds/show.html.haml
@@ -4,7 +4,8 @@
 %strong{:class => project_status(@build.status)}= "#{project_status(@build.status)}"
 - if @build.revision
   %div= "Revision: #{@build.revision}"
-= @build.timestamp.strftime("%a, %Y/%m/%d %I:%M%p %Z")
+%div
+  - format_timestamp(@build.timestamp)
 %pre= @build.change_list
 %pre= @build.log
 

--- a/app/views/home/_project.html.haml
+++ b/app/views/home/_project.html.haml
@@ -9,6 +9,6 @@
       %b= project.name
 
   %td.last_built_at
-    - if project.latest_build_timestamp
-      = project.latest_build_timestamp.strftime("%a, %Y/%m/%d %I:%M%p %Z")
+    - if project.latest_build_timestamp        
+      - format_timestamp(project.latest_build_timestamp)
 

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -21,5 +21,5 @@
 
       %td.last_built_at
         - if project.latest_build_timestamp
-          = project.latest_build_timestamp.strftime("%a, %Y/%m/%d %I:%M%p %Z")
+          - format_timestamp(project.latest_build_timestamp)
 

--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -8,7 +8,7 @@
     - @project.builds.each do |build|
       %li
         %a{:href => "/projects/#{@project.name}/builds/#{build.id}"}= "#{build.number} #{project_status(build.status)}"
-        - if build.timestamp
-          = build.timestamp.strftime("%a, %Y/%m/%d %I:%M%p %Z")
+        - if build.timestamp   
+          - format_timestamp(build.timestamp)
         - if build.revision
           = build.revision

--- a/public/stylesheets/dashboard.css
+++ b/public/stylesheets/dashboard.css
@@ -23,7 +23,7 @@
 }
 
 #all_projects tr.project_row td.last_built_at {
-    width: 20%;
+    width: 27%;
 }
 
 #all_projects tr.project_row td.number_of_tests {


### PR DESCRIPTION
Two simple changes.

a) timestamps will now show how long ago the build was -- personally, I find this easier to understand than the timestamp itself
Sat, 2011/04/16 05:51AM UTC ( 1 day ago )

b) the calls to print out the timestamp have been refactored into one helper method. DRY
