### PR TITLE
Adding green/red colors to the builds view

### DIFF
--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -1,3 +1,5 @@
+- content_for(:head) do
+  %link{:rel => 'stylesheet', :href => '/stylesheets/dashboard.css', :type => 'text/css'}
 %p
   %h2= @project.name
   %strong{:class => project_status(@project)}= "#{project_status(@project)}"
@@ -6,7 +8,7 @@
   %pre= @project.latest_build_log
   %ul
     - @project.builds.each do |build|
-      %li
+      %li{:class => "#{build_status(build)}"}
         %a{:href => "/projects/#{@project.name}/builds/#{build.id}"}= "#{build.number} #{build_status(build)}"
         - if build.timestamp
           = format_timestamp(build.timestamp)

--- a/public/stylesheets/dashboard.css
+++ b/public/stylesheets/dashboard.css
@@ -11,7 +11,19 @@
 }
 
 #all_projects tr.project_row.building td {
-    background-color: yellow
+    background-color: yellow;
+}
+
+li.passed {
+    background-color: #ccf0cc;	   
+}
+
+li.failed {
+    background-color: #f0cccc;	   
+}     
+
+li.building {
+    background-color: yellow;  
 }
 
 /* Table Columns */


### PR DESCRIPTION
I wanted the "builds" page to look more like the "projects" dashboard page with respect to colors. I'd like to quickly see which builds have been passing vs failing via colors. 

I started to do my treatment on the "builds" page but I came across some obstacles that are probably faster for you to solve since you know the original code base better than me.

a) the html construct of the project page is table with <td>, the html construct of the build list is a list with <li>

b) it wasn't clear to me if you wanted one css file for the entire project, or one css file for each view. 

My suggestion is to rewrite the code that generate the builds list (ie the <li>) and convert it into a table structure like the project page. It's almost midnight here and I don't trust my coding skills at this point. =)
