### PR TITLE
Ability to add after_build hooks - Issue #38

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -64,6 +64,8 @@ Every project in goldberg can have its own custom configuration by means of addi
   Project.configure do |config|
     config.frequency = 20
     config.ruby = '1.9.2' # Your server needs to have rvm installed for this setting to be considered
+    config.environment_variables.update("FOO" => "bar")
+    config.after_build Proc.new { |build, project| `touch ~/Desktop/actually_built`}
   end
 
 If you want the project to be checked for updates every 5 seconds, you will need to change the poller frequency to less than 5 seconds using <tt>goldberg.yml</tt> as mentioned above.

--- a/app/models/hook_runner.rb
+++ b/app/models/hook_runner.rb
@@ -1,0 +1,16 @@
+class HookRunner
+  def initialize(hooks)
+    @hooks = hooks
+  end
+
+  def execute(build, project)
+    execute_hook(@hooks, build, project)
+  end
+
+  private
+  def execute_hook(hook, build, project)
+    hook.execute(build, project) if hook.respond_to? :execute
+    hook.call(build, project) if hook.is_a? Proc
+    hook.each { |h| execute_hook(h, build, project) } if hook.is_a? Enumerable
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -63,9 +63,14 @@ class Project < ActiveRecord::Base
                                               :environment_string => environment_string).run
       self.build_requested = false
       Rails.logger.info "Build #{ build_successful ? "passed" : "failed!" }"
+      after_build_runner.execute(latest_build, self)
     end
     self.next_build_at = Time.now + frequency.seconds
     self.save
+  end
+
+  def after_build_runner
+    HookRunner.new config.after_build
   end
 
   def force_build

--- a/app/models/project_config.rb
+++ b/app/models/project_config.rb
@@ -7,9 +7,15 @@ class ProjectConfig
     @ruby = RUBY_VERSION
     @rake_task = :default
     @environment_variables = {}
+    @after_build = []
   end
 
   def environment_string
     @environment_variables.each_pair.map { |k, v| "#{k}=#{v}" }.join(" ")
+  end
+
+  def after_build(*args)
+    @after_build = args unless args.empty?
+    @after_build
   end
 end

--- a/spec/models/hook_runner_spec.rb
+++ b/spec/models/hook_runner_spec.rb
@@ -1,0 +1,27 @@
+require "spec_helper"
+
+describe HookRunner do
+  let(:project) { mock }
+  let(:build) { mock }
+
+  it "should be able to execute callbacks on an object implementing execute" do
+    foo = mock
+    foo.should_receive(:respond_to?).with(:execute).and_return(true)
+    foo.should_receive(:execute).with(build, project)
+    HookRunner.new(foo).execute(build, project)
+  end
+
+  it "should be able to execute a procedure" do
+    a = false
+    foo = Proc.new { a = true }
+    HookRunner.new(foo).execute(build, project)
+    a.should be_true
+  end
+
+  it "should be able to execute a list of commands" do
+    a = 0
+    foo = Proc.new { a = a + 1 }
+    HookRunner.new([foo, foo]).execute(build, project)
+    a.should == 2
+  end
+end

--- a/spec/models/project_config_spec.rb
+++ b/spec/models/project_config_spec.rb
@@ -13,6 +13,10 @@ describe ProjectConfig do
       config.environment_variables.should == {}
       config.environment_string.should == ""
     end
+
+    it "should have no after_build hook set" do
+      config.after_build.should == []
+    end
   end
 
   context "setting values" do
@@ -23,6 +27,14 @@ describe ProjectConfig do
       end
       c.environment_variables.should == { "FOO" => "bar" }
       c.environment_string.should == "FOO=bar"
+    end
+
+    it "should be able to store after_build commands" do
+      foo = mock
+      c = Project.configure do |config|
+        config.after_build foo
+      end
+      c.after_build.should == [foo]
     end
   end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -213,6 +213,16 @@ describe Project do
         project.builds.should_receive(:create!).with(hash_including(:environment_string => "FOO=bar")).and_return(build)
         project.run_build
       end
+
+      it "should execute the post_build hooks from the config" do
+        hook = Object.new.tap { |h| h.should_receive(:execute).with(build, project) }
+        config = ProjectConfig.new.tap{ |c| c.stub(:after_build).and_return(hook) }
+        
+        project.stub(:config).and_return(config)
+        project.builds.stub(:create!).and_return(build)
+
+        project.run_build
+      end
     end
   end
 


### PR DESCRIPTION
I've updated the documentation as well

config.after_build Proc.new{}, Proc.new...
or
config.after_build foo

where foo respond_to? execute(build, project)
