### PR TITLE
Fix for Project comparison

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -3,7 +3,7 @@ class HomeController < ApplicationController
 
   def load_projects
     @projects = Project.all.sort do |x, y|
-      y.latest_build.updated_at <=> x.latest_build.updated_at
+      (y.latest_build.updated_at || DateTime.now) <=> (x.latest_build.updated_at || DateTime.now)
     end
   end
 

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -22,6 +22,17 @@ describe HomeController do
         response.should be_ok
         assigns[:projects].should == [new_project, old_project]
       end
+
+      it "can sort projects with no latest build" do
+        previously_built_project = mock('project')
+        real_build = mock('build')
+        real_build.should_receive('updated_at').and_return(DateTime.now)
+        previously_built_project.should_receive(:latest_build).and_return(real_build)
+        project_with_no_build = mock('project')
+        project_with_no_build.should_receive(:latest_build).and_return(Build.nil)
+        Project.should_receive(:all).and_return([previously_built_project, project_with_no_build])
+        controller.load_projects
+      end
     end
   end
 

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -32,6 +32,7 @@ describe HomeController do
         project_with_no_build.should_receive(:latest_build).and_return(Build.nil)
         Project.should_receive(:all).and_return([previously_built_project, project_with_no_build])
         controller.load_projects
+        assigns[:projects].should == [project_with_no_build, previously_built_project]
       end
     end
   end


### PR DESCRIPTION
This pull assumes a project which has no latest_build should be sorted at the top of the list on the index page.  Normally, if you get into this state (I believe by adding your second goldberg project while the first one is mid-run), you would have to reboot the server to resolve the error.
