### PR TITLE
Link to build page in status mail does not work

### DIFF
--- a/app/views/build_status_mailer/status_mail.html.erb
+++ b/app/views/build_status_mailer/status_mail.html.erb
@@ -1,3 +1,4 @@
 Project : <%= @project.name %><br/>
 Build Status : <%= @build.status %><br/>
-Build Page URL : <%= project_build_url(@project.name,@build) %>
+Build Page URL : <%= project_build_url(@project.name,@build.number) %>
+

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -2,6 +2,10 @@ Factory.sequence :project_name do |n|
   "project_#{n}"
 end
 
+Factory.sequence :build_number do |n|
+  n
+end
+
 Factory.define :project do |p|
   p.name { Factory.next(:project_name) }
   p.url  { |project| "git://domain/#{project.name}.git" }
@@ -10,6 +14,7 @@ end
 
 Factory.define :build do |b|
   b.project { Factory(:project) }
+  b.number  { Factory.next(:build_number) }
   b.revision "some_random_sha"
 end
 

--- a/spec/mailers/build_status_mailer_spec.rb
+++ b/spec/mailers/build_status_mailer_spec.rb
@@ -7,5 +7,12 @@ describe BuildStatusMailer do
       BuildStatusMailer.status_mail('from','to',nil,build).deliver
       ActionMailer::Base.deliveries.first.subject.should == "#{build.project.name} build #{build.status}"
     end
+
+    it "delivers a mail with a link pointing to the build page" do
+      build = Factory.create(:build, :status => 'passed')
+      BuildStatusMailer.status_mail('from','to',nil,build).deliver
+      ActionMailer::Base.deliveries.first.body.should match(project_build_url(build.project.name, build.number))
+    end
   end
 end
+


### PR DESCRIPTION
Build id is being used instead of build number.
