### PR TITLE
Issue #83 - Redo niceness control using `nice` instead of `renice` becaus

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,11 @@ Every project in Goldberg can have its own custom configuration by checking in a
         config.environment_variables = {"FOO" => "bar"}
         config.after_build lambda { |build, project| `touch ~/Desktop/actually_built` }
         config.timeout = 10.minutes
-        config.nice = '+5'        # Use this to reduce the scheduling priority (increase niceness) of CPU
+        config.nice = 5           # Use this to reduce the scheduling priority (increase niceness) of CPU
                                   # intensive builds that may otherwise leave the Goldberg web application
-                                  # unresponsive. Uses the UNIX `renice` command. Defaults to '+0'.
+                                  # unresponsive. Uses the UNIX `nice` command. Defaults to '0'.
+                                  # Positive values have lower priority with a max of 19 on OSX and 20 on
+                                  # Linux. You can set negative values, but we don't see the point.
         config.command = 'make'   # To be used if you're using anything other than rake
         config.rake_task = 'ci'   # To be used if your CI build runs something other than the default task
       end

--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -64,7 +64,6 @@ class Build < ActiveRecord::Base
     start_time = DateTime.now
     command = Command.new(command)
     command.execute_async
-    command.renice!(project.nice)
     while(DateTime.now < start_time + project.timeout && command.running?)
       sleep(10)
     end

--- a/app/models/command.rb
+++ b/app/models/command.rb
@@ -8,7 +8,8 @@ class Command
   end
 
   def execute_async
-    @process = ChildProcess.build(%{/usr/bin/env bash -c "#{@cmd.gsub(/"/, '\"')}"})
+    command = %{/usr/bin/env bash -c "#{@cmd.gsub(/"/, '\"')}"}
+    @process = ChildProcess.build(command)
     @process.start
   end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -85,8 +85,10 @@ class Project < ActiveRecord::Base
   end
 
   def build_command
+    build_command = config.command || "rake #{config.rake_task}"
+    niced_command = "nice -n #{config.nice} #{build_command}"
     bundler_command = File.exists?(File.join(self.code_path, 'Gemfile')) ? "(#{Bundle.check_and_install}) && " : ""
-    bundler_command << (config.command || "rake #{config.rake_task}")
+    bundler_command << niced_command
   end
 
   def map_to_cctray_project_status

--- a/app/models/project_config.rb
+++ b/app/models/project_config.rb
@@ -13,7 +13,7 @@ class ProjectConfig
     @build_fixed_callbacks = []
     @timeout = 10.minutes
     @command = nil
-    @nice = '+0'
+    @nice = 0
   end
 
   def environment_string

--- a/spec/models/command_spec.rb
+++ b/spec/models/command_spec.rb
@@ -1,18 +1,4 @@
 require 'spec_helper'
 
 describe Command do
-  it "knows how to renice its process" do
-    command = Command.new('sleep 1')
-    command.execute_async
-    command.renice!('+2')
-    
-    niceness_of(command).should eq('2')
-  end
-  
-  def niceness_of(command)
-    status = `ps -l #{command.pid}`
-    headers, values = status.split("\n")
-    niceness_column = headers.split(' ').map{|header| header.strip}.index('NI')
-    values.split(' ').map{|value| value.strip}[niceness_column]
-  end
 end

--- a/spec/models/project_config_spec.rb
+++ b/spec/models/project_config_spec.rb
@@ -14,7 +14,7 @@ describe ProjectConfig do
     end
 
     it "for niceness of the build process should be +0" do
-      config.nice.should eq('+0')
+      config.nice.should eq(0)
     end
     
     it "should have no callbacks set" do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -104,12 +104,11 @@ describe Project do
       File.should_receive(:exists?).with(File.join(project.code_path, 'Gemfile'))
       File.stub!(:exists?).with(File.expand_path('goldberg_config.rb', project.code_path)).and_return(true)
       Environment.stub!(:read_file).with(File.expand_path('goldberg_config.rb', project.code_path)).and_return("Project.configure { |config| config.command = 'cmake' }")
-      project.build_command.should == 'cmake'
+      project.build_command.should eq('nice -n 0 cmake')
     end
 
     it "defaults the custom command to rake" do
-      project = Factory(:project)
-      project.build_command.should == 'rake default'
+      Factory(:project).build_command.should eq('nice -n 0 rake default')
     end
   end
 


### PR DESCRIPTION
Issue #83 - Redo niceness control using `nice` instead of `renice` because `renice` doesn't change the niceness of child processes forked before it was applied
