### PR TITLE
Post build hooks did not receive the current build

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -64,7 +64,7 @@ class Project < ActiveRecord::Base
                                       :environment_string => environment_string).tap(&:run)
       self.build_requested = false
       Rails.logger.info "Build #{ new_build.status }"
-      after_build_runner.execute(latest_build, previous_build_status)
+      after_build_runner.execute(new_build, previous_build_status)
     end
     self.next_build_at = Time.now + frequency.seconds
     self.save

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -231,12 +231,15 @@ describe Project do
 
         BuildMailNotification.stub!(:new).and_return(mail_notification)
         configuration = Project.configure do |config|
-          config.on_build_completion do |build,notification|
-            callback_tester.test_call(build,notification)
+          config.on_build_completion do |build,notification, prev_build_status|
+            callback_tester.test_call(build,notification,prev_build_status)
           end
         end
 
-        callback_tester.should_receive(:test_call).with(build,mail_notification)
+        latest_build = Build.new :number => 8, :status => 'prev_status'
+        project.builds << latest_build
+
+        callback_tester.should_receive(:test_call).with(build,mail_notification,'prev_status')
 
         project.stub(:config).and_return(configuration)
         project.builds.stub(:create!).and_return(build)


### PR DESCRIPTION
Latest build was being passed instead of the current build thus a new build executed the hooks for the previous one. Also on_build_fixed callback was never invoked.
