### PR TITLE
Fixing rvm spec failure

### DIFF
--- a/spec/models/rvm_spec.rb
+++ b/spec/models/rvm_spec.rb
@@ -5,8 +5,8 @@ describe RVM do
     Env.stub!(:[]).with('HOME').and_return('home')
   end
 
+  paths = {'user' => 'home/.rvm/scripts/rvm', 'server' => '/usr/local/rvm/scripts/rvm',}
   context "installed?" do
-    paths = {'user' => 'home/.rvm/scripts/rvm', 'server' => '/usr/local/rvm/scripts/rvm',}
     paths.each do |installation_type, path|
       context "for #{installation_type}" do
         before(:each) do
@@ -40,6 +40,8 @@ describe RVM do
 
   context "not installed?" do
     it "generates a nil 'rvm use' script" do
+      File.stub!(:exist?).with(paths['user']).and_return(false)
+      File.stub!(:exist?).with(paths['server']).and_return(false)
       RVM.use_script('ruby', 'a_gemset').should be_nil
     end
   end


### PR DESCRIPTION
1) RVM not installed? generates a nil 'rvm use' script
     Failure/Error: RVM.use_script('ruby', 'a_gemset').should be_nil
       expected: nil
            got: "source /usr/local/rvm/scripts/rvm && rvm use --create ruby@a_gemset"

Was failing on my machine because the class seemed have found the file /usr/local/rvm/scripts/rvm so stubbing out for non-existence in spec.
