### PR TITLE
Add support for foreman

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,8 @@ gem 'commander', '~> 4.0.4'
 gem 'childprocess', '~> 0.1.9'
 gem 'json', :platforms => [:ruby_18, :jruby]
 
+gem 'foreman', "~> 0.22.0"
+
 platform :jruby do
   gem 'jdbc-sqlite3', '~> 3.6.0'
   gem 'activerecord-jdbcsqlite3-adapter'

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+app: bundle exec rails server
+poller: bundle exec bin/goldberg start_poller


### PR DESCRIPTION
Added support for foreman. Starting Goldberg is now as easy as `foreman start`, and you can optionally create init scripts if you want.
