### PR TITLE
Use git fetch && git reset --hard origin/branch instead of git pull

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -16,7 +16,7 @@ class Repository
 
   def update
     rev_before_update = revision
-    Command.new("cd #{@code_path} && #{@provider.update}").execute
+    Command.new("cd #{@code_path} && #{@provider.update(@branch)}").execute
     rev_after_update = revision
     rev_before_update != rev_after_update
   end

--- a/app/models/scm/git.rb
+++ b/app/models/scm/git.rb
@@ -9,8 +9,8 @@ module Scm
         "git clone --depth 1 #{url} #{code_path} --branch #{branch}"
       end
 
-      def update
-        "git reset --hard && git pull && git submodule update --init --recursive"
+      def update(branch)
+        "git fetch && git reset --hard origin/#{branch} && git submodule update --init --recursive"
       end
 
       def change_list(old_rev, new_rev)

--- a/app/models/scm/svn.rb
+++ b/app/models/scm/svn.rb
@@ -9,7 +9,7 @@ module Scm
         "svn co #{url} #{code_path}"
       end
       
-      def update
+      def update(branch)
         "svn revert . && svn update"
       end
       


### PR DESCRIPTION
This should allow for rebasing workflows and other history rewriting operations as well.

Added the param to svn to prevent the builder crashing but it appears to not use the branch anyway.
