### PR TITLE
Project specific environment variable

### DIFF
--- a/.ruby-gemset
+++ b/.ruby-gemset
@@ -1,0 +1,1 @@
+goldberg

--- a/app/models/init.rb
+++ b/app/models/init.rb
@@ -1,8 +1,8 @@
 require 'fileutils'
 
 class Init
-  def add(url, name, branch, scm)
-    if Project.add(url: url, name: name, branch: branch, scm: scm)
+  def add(url, name, branch, scm, env)
+    if Project.add(url: url, name: name, branch: branch, scm: scm, env: env)
       Goldberg.logger.info "#{name} successfully added."
     else
       Goldberg.logger.info "There was problem adding the project."

--- a/bin/goldberg
+++ b/bin/goldberg
@@ -9,20 +9,23 @@ program :version, '0.0.1'
 program :description, 'Yet another CI server. With pipelines.'
 
 command :add do |c|
-  c.syntax = 'goldberg add <url> <name> [--branch <branch_name>] [--scm <scm_type>]'
-  c.description = 'Add a new codebase to build'
+  c.syntax = 'goldberg add <url> <name> [--branch <branch_name>] [--scm <scm_type>] [--env <key=value>]'
+  c.description = 'Add a new project to build'
   c.option '--branch STRING', String, 'branch to build, defaults to \'master\''
   c.option '--scm STRING', String, "scm to use - 'git' and 'svn' are currently supported, defaults to 'git'"
+  c.option '--env key=value', Array, 'comma seperated list of environment vars for building project, eg: --env RAILS_ENV="production",RACK_ENV="production"'
   c.action do |args, options|
     options.default branch: 'master'
     options.default scm: 'git'
+    options.default env: []
 
     url = argument_value(args[0], "Url")
     name = argument_value(args[1], "Name")
     branch = options.branch
     scm = options.scm
+    env = options.env
 
-    Init.new.add(url, name, branch, scm)
+    Init.new.add(url, name, branch, scm, env)
   end
 end
 

--- a/db/migrate/20140611165611_add_project_specific_env_variables.rb
+++ b/db/migrate/20140611165611_add_project_specific_env_variables.rb
@@ -1,0 +1,6 @@
+class AddProjectSpecificEnvVariables < ActiveRecord::Migration
+  def change
+    add_column :projects, :env_string, :string, default: ''
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -9,17 +9,17 @@
 # from scratch. The latter is a flawed and unsustainable approach (the more migrations
 # you'll amass, the slower it'll run and the greater likelihood for issues).
 #
-# It's strongly recommended to check this file into your version control system.
+# It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20110629172404) do
+ActiveRecord::Schema.define(version: 20140611165611) do
 
   create_table "builds", force: true do |t|
     t.integer  "project_id"
     t.integer  "number"
     t.string   "revision"
     t.string   "change_list"
-    t.datetime "created_at",         null: false
-    t.datetime "updated_at",         null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.string   "status"
     t.string   "ruby"
     t.string   "environment_string"
@@ -28,12 +28,13 @@ ActiveRecord::Schema.define(version: 20110629172404) do
   create_table "projects", force: true do |t|
     t.string   "name"
     t.string   "url"
-    t.datetime "created_at",                         null: false
-    t.datetime "updated_at",                         null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.boolean  "build_requested", default: false
     t.string   "branch"
     t.datetime "next_build_at"
     t.string   "scm"
+    t.string   "env_string",      default: ""
   end
 
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -4,6 +4,7 @@ FactoryGirl.define do
     p.url  { |project| "git://domain/#{project.name}.git" }
     p.scm 'git'
     p.branch 'master'
+    p.env_string ''
   end
 
   factory :build do |b|

--- a/spec/models/init_spec.rb
+++ b/spec/models/init_spec.rb
@@ -2,21 +2,21 @@ require 'spec_helper'
 
 describe Init do
   it "adds a new project" do
-    Project.should_receive(:add).with(url: 'url', name: 'name', branch: 'master', scm: 'git').and_return(true)
+    Project.should_receive(:add).with(url: 'url', name: 'name', branch: 'master', scm: 'git', env: []).and_return(true)
     Goldberg.logger.should_receive(:info).with('name successfully added.')
-    Init.new.add('url', 'name', 'master', 'git')
+    Init.new.add('url', 'name', 'master', 'git', [])
   end
 
   it "adds a new project with a custom command" do
-    Project.should_receive(:add).with(url: 'url', name: 'name', branch: 'master', scm: 'svn').and_return(true)
+    Project.should_receive(:add).with(url: 'url', name: 'name', branch: 'master', scm: 'svn', env: ['key=value']).and_return(true)
     Goldberg.logger.should_receive(:info).with('name successfully added.')
-    Init.new.add('url', 'name', 'master', 'svn')
+    Init.new.add('url', 'name', 'master', 'svn', ['key=value'])
   end
 
   it "reports failure in adding a project" do
     Project.should_receive(:add).and_return(false)
     Goldberg.logger.should_receive(:info).with("There was problem adding the project.")
-    Init.new.add('url', 'name', 'master', 'svn')
+    Init.new.add('url', 'name', 'master', 'svn', [])
   end
 
   it "removes the specified project" do

--- a/spec/models/project/configuration_spec.rb
+++ b/spec/models/project/configuration_spec.rb
@@ -38,7 +38,7 @@ describe Project::Configuration do
 
     it "get formatted into a string" do
       config.environment_variables = { "foo" => 1, "bar" => 2 }
-      config.environment_string.should == "foo=1 bar=2"
+      config.environment_string.should == 'foo=1 bar=2'
     end
   end
 


### PR DESCRIPTION
This is a followup to an old issue [#157](https://github.com/srushti/goldberg/pull/157).

I've cleaned up the PR and added tests for the changes.

Its useful when we need run same project under two different configurations. For example if we need to run `rake ci` and `foo=bar rake ci`.

This would serve as an additional option to set the environment variable, instead of creating a local goldberg_config.rb for the custom project in the CI box.
